### PR TITLE
I've added the new feature to track Cardmarket price history.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ python src/main.py --retries 5 --delay 3
     - Date de dernière mise à jour des prix
     - Mise à jour uniquement si le nouveau prix est inférieur
     - Stockage des URLs Vinted
+    - Enregistrement de chaque vérification de prix Cardmarket dans un onglet 'Historique' dédié.
 - [ ] Scraping des prix Ebay
 - [ ] Scraping des prix Leboncoin
 - [ ] Système d'alertes de prix

--- a/src/config.py
+++ b/src/config.py
@@ -9,6 +9,7 @@ class Settings(BaseSettings):
     google_sheets_url: str
     google_sheets_credentials_file: str = "service-account.json"
     sheet_name: str = "data"
+    history_sheet_name: str = "Historique"
     log_level: str = "DEBUG"
 
     # SMTP Configuration

--- a/src/main.py
+++ b/src/main.py
@@ -8,6 +8,7 @@ from sheets import (
     get_sheet_id,
     update_card_prices,
     update_vinted_price,
+    log_price_history,
 )
 from utils.logger import setup_logger
 from config import get_settings
@@ -29,6 +30,14 @@ def process_card(card, service, sheet_id, sheet_name, sources):
         if cardmarket_price_info:
             update_card_prices(
                 service, sheet_id, sheet_name, card.row, cardmarket_price_info
+            )
+            log_price_history(
+                service,
+                sheet_id,
+                settings.history_sheet_name,
+                card.name_fr,
+                cardmarket_price_info.current_price,
+                "Cardmarket",
             )
             latest_cardmarket_price = cardmarket_price_info.current_price
 

--- a/src/sheets.py
+++ b/src/sheets.py
@@ -195,3 +195,42 @@ def update_vinted_price(
 
     except Exception as e:
         logger.error(f"Erreur lors de la mise à jour du prix Vinted dans le sheet: {e}")
+
+
+def log_price_history(
+    service,
+    sheet_id: str,
+    history_sheet_name: str,
+    card_name: str,
+    price: float,
+    source: str,
+):
+    """Enregistre une entrée de prix dans l'onglet d'historique."""
+    try:
+        paris_tz = pytz.timezone("Europe/Paris")
+        current_time = datetime.now(paris_tz).strftime("%d/%m/%Y %H:%M:%S")
+
+        row_to_append = [
+            card_name,
+            current_time,
+            price,
+            source,
+        ]
+
+        body = {"values": [row_to_append]}
+
+        service.spreadsheets().values().append(
+            spreadsheetId=sheet_id,
+            range=f"{history_sheet_name}!A1",
+            valueInputOption="RAW",
+            insertDataOption="INSERT_ROWS",
+            body=body,
+        ).execute()
+        logger.info(
+            f"Historique de prix pour '{card_name}' enregistré : {price}€ ({source})"
+        )
+
+    except Exception as e:
+        logger.error(
+            f"Erreur lors de l'enregistrement de l'historique pour '{card_name}': {e}"
+        )


### PR DESCRIPTION
This feature logs price checks from Cardmarket to a separate 'Historique' sheet in your Google Sheets. To implement this, I created a new `log_price_history` function in `sheets.py` to handle appending the new data (card name, timestamp, price, and source). This function is called from `main.py` after a price is successfully retrieved.

For more flexibility, I made the name of the history sheet configurable in `config.py`.

Finally, I updated the `README.md` to reflect this new capability.